### PR TITLE
Fix UI stops but not restarted when nothing to lock!

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -172,17 +172,17 @@ fn lock(mut forbidden: Vec<String>, unlock_at: Time, allow_sync: bool) -> Result
         for path in &missing {
             warn!("could not find: {path}, if it was not deleted or renamed this is a bug");
         }
-        if to_lock.is_empty() {
-            warn!("Found nothing to lock, is folder empty?");
-            return Ok(())
-        }
-        let pdf = report::build(tree, roots, missing, unlock_at);
-        report::save(pdf).wrap_err("Could not save locked files report")?;
+        if !to_lock.is_empty() {
+            let pdf = report::build(tree, roots, missing, unlock_at);
+            report::save(pdf).wrap_err("Could not save locked files report")?;
 
-        if !allow_sync {
-            sync::block().wrap_err("Could not block sync")?;
+            if !allow_sync {
+                sync::block().wrap_err("Could not block sync")?;
+            }
+            move_docs(to_lock).wrap_err("Could not move book data")?;
+        } else {
+            warn!("Found nothing to lock, is folder empty?");
         }
-        move_docs(to_lock).wrap_err("Could not move book data")?;
     }
     systemd::reset_failed()?;
     systemd::ui_action("start").wrap_err("Could not start gui")

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,8 +154,10 @@ fn unlock() -> Result<()> {
 }
 
 fn lock(mut forbidden: Vec<String>, unlock_at: Time, allow_sync: bool) -> Result<()> {
+    // if we did not lock the ui before building the file tree the ui could
+    // modify the tree while or after we are building it.
     systemd::ui_action("stop").wrap_err("Could not stop gui")?;
-    {
+    'lock_or_dont: {
         unlock_files().wrap_err("could not unlock files")?; // ensure nothing is in locked folder
 
         let (tree, _) = directory::map().wrap_err("Could not build document tree")?;
@@ -172,17 +174,18 @@ fn lock(mut forbidden: Vec<String>, unlock_at: Time, allow_sync: bool) -> Result
         for path in &missing {
             warn!("could not find: {path}, if it was not deleted or renamed this is a bug");
         }
-        if !to_lock.is_empty() {
-            let pdf = report::build(tree, roots, missing, unlock_at);
-            report::save(pdf).wrap_err("Could not save locked files report")?;
 
-            if !allow_sync {
-                sync::block().wrap_err("Could not block sync")?;
-            }
-            move_docs(to_lock).wrap_err("Could not move book data")?;
-        } else {
+        if to_lock.is_empty() {
             warn!("Found nothing to lock, is folder empty?");
+            break 'lock_or_dont;
         }
+
+        let pdf = report::build(tree, roots, missing, unlock_at);
+        report::save(pdf).wrap_err("Could not save locked files report")?;
+        if !allow_sync {
+            sync::block().wrap_err("Could not block sync")?;
+        }
+        move_docs(to_lock).wrap_err("Could not move book data")?;
     }
     systemd::reset_failed()?;
     systemd::ui_action("start").wrap_err("Could not start gui")


### PR DESCRIPTION
When there is nothing to lock (for example when running on an empty folder), the UI would be stopped but not restarted, which makes the reMarkable hang.

The UI is now restarted when locking an empty folder, might be neater to not stop it in the first place.